### PR TITLE
Implement core chunk streaming pipeline

### DIFF
--- a/Assets/Scripts/World/ChunkConfig.cs
+++ b/Assets/Scripts/World/ChunkConfig.cs
@@ -1,0 +1,55 @@
+using Unity.Mathematics;
+
+namespace RobbieCraft.World
+{
+    /// <summary>
+    /// Central configuration and helper utilities for RobbieCraft's voxel world.
+    /// </summary>
+    public static class ChunkConfig
+    {
+        /// <summary>
+        /// Width of a chunk in blocks.
+        /// </summary>
+        public const int ChunkSizeX = 16;
+
+        /// <summary>
+        /// Height of a chunk in blocks.
+        /// </summary>
+        public const int ChunkSizeY = 128;
+
+        /// <summary>
+        /// Depth of a chunk in blocks.
+        /// </summary>
+        public const int ChunkSizeZ = 16;
+
+        /// <summary>
+        /// Total number of blocks contained in a single chunk.
+        /// </summary>
+        public const int BlocksPerChunk = ChunkSizeX * ChunkSizeY * ChunkSizeZ;
+
+        /// <summary>
+        /// Size of the safe, flat spawn area in chunks.
+        /// </summary>
+        public const int SpawnAreaSize = 2; // 32x32 blocks when multiplied by chunk size.
+
+        /// <summary>
+        /// Index helper that flattens a 3D block position inside a chunk to a 1D array index.
+        /// </summary>
+        public static int ToIndex(int x, int y, int z)
+        {
+            return x + ChunkSizeX * (z + ChunkSizeZ * y);
+        }
+
+        /// <summary>
+        /// Converts a block index back into a <see cref="int3"/> coordinate relative to the chunk.
+        /// </summary>
+        public static int3 ToCoordinate(int index)
+        {
+            int y = index / (ChunkSizeX * ChunkSizeZ);
+            int remaining = index - (y * ChunkSizeX * ChunkSizeZ);
+            int z = remaining / ChunkSizeX;
+            int x = remaining - (z * ChunkSizeX);
+            return new int3(x, y, z);
+        }
+    }
+}

--- a/Assets/Scripts/World/ChunkCoordinate.cs
+++ b/Assets/Scripts/World/ChunkCoordinate.cs
@@ -1,0 +1,48 @@
+using System;
+using Unity.Mathematics;
+
+namespace RobbieCraft.World
+{
+    /// <summary>
+    /// Value type representing the grid position of a chunk in the infinite world.
+    /// </summary>
+    [Serializable]
+    public struct ChunkCoordinate : IEquatable<ChunkCoordinate>
+    {
+        /// <summary>
+        /// X grid index of the chunk.
+        /// </summary>
+        public int X;
+
+        /// <summary>
+        /// Z grid index of the chunk.
+        /// </summary>
+        public int Z;
+
+        public ChunkCoordinate(int x, int z)
+        {
+            X = x;
+            Z = z;
+        }
+
+        /// <summary>
+        /// Converts the chunk coordinate into world-space position of the chunk origin.
+        /// </summary>
+        public float3 ToWorldPosition(float heightOffset = 0f)
+        {
+            return new float3(X * ChunkConfig.ChunkSizeX, heightOffset, Z * ChunkConfig.ChunkSizeZ);
+        }
+
+        public bool Equals(ChunkCoordinate other) => X == other.X && Z == other.Z;
+
+        public override bool Equals(object obj) => obj is ChunkCoordinate other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(X, Z);
+
+        public static bool operator ==(ChunkCoordinate left, ChunkCoordinate right) => left.Equals(right);
+
+        public static bool operator !=(ChunkCoordinate left, ChunkCoordinate right) => !left.Equals(right);
+
+        public override string ToString() => $"Chunk({X}, {Z})";
+    }
+}

--- a/Assets/Scripts/World/ChunkData.cs
+++ b/Assets/Scripts/World/ChunkData.cs
@@ -1,0 +1,54 @@
+using System;
+using Unity.Collections;
+
+namespace RobbieCraft.World
+{
+    /// <summary>
+    /// Stores block data for a single chunk in a native-friendly structure.
+    /// </summary>
+    public sealed class ChunkData : IDisposable
+    {
+        private NativeArray<byte> _blocks;
+
+        /// <summary>
+        /// Creates a new chunk data container with native storage.
+        /// </summary>
+        public ChunkData(Allocator allocator)
+        {
+            _blocks = new NativeArray<byte>(ChunkConfig.BlocksPerChunk, allocator, NativeArrayOptions.ClearMemory);
+        }
+
+        /// <summary>
+        /// Gets or sets the block id for a given block coordinate in the chunk.
+        /// </summary>
+        public byte this[int x, int y, int z]
+        {
+            get => _blocks[ChunkConfig.ToIndex(x, y, z)];
+            set => _blocks[ChunkConfig.ToIndex(x, y, z)] = value;
+        }
+
+        /// <summary>
+        /// Provides raw access to the internal block array.
+        /// </summary>
+        public NativeArray<byte> RawData => _blocks;
+
+        /// <summary>
+        /// Fills the entire chunk with a single block type.
+        /// </summary>
+        public void Fill(byte blockId)
+        {
+            for (int i = 0; i < _blocks.Length; i++)
+            {
+                _blocks[i] = blockId;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_blocks.IsCreated)
+            {
+                _blocks.Dispose();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/World/ChunkGenerationJob.cs
+++ b/Assets/Scripts/World/ChunkGenerationJob.cs
@@ -1,0 +1,34 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Jobs;
+using Unity.Mathematics;
+
+namespace RobbieCraft.World
+{
+    /// <summary>
+    /// Generates voxel data for a chunk using layered Perlin noise.
+    /// </summary>
+    [BurstCompile]
+    public struct ChunkGenerationJob : IJobParallelFor
+    {
+        public ChunkCoordinate Coordinate;
+        public NativeArray<byte> Blocks;
+        public float BaseHeight;
+        public float NoiseScale;
+        public float HeightAmplitude;
+        public byte GroundBlockId;
+        public byte AirBlockId;
+
+        public void Execute(int index)
+        {
+            int3 localPos = ChunkConfig.ToCoordinate(index);
+            int worldX = Coordinate.X * ChunkConfig.ChunkSizeX + localPos.x;
+            int worldZ = Coordinate.Z * ChunkConfig.ChunkSizeZ + localPos.z;
+
+            float height = BaseHeight + noise.snoise(new float2(worldX, worldZ) * NoiseScale) * HeightAmplitude;
+            int terrainHeight = math.clamp((int)math.round(height), 0, ChunkConfig.ChunkSizeY - 1);
+
+            Blocks[index] = localPos.y <= terrainHeight ? GroundBlockId : AirBlockId;
+        }
+    }
+}

--- a/Assets/Scripts/World/ChunkGreedyMesher.cs
+++ b/Assets/Scripts/World/ChunkGreedyMesher.cs
@@ -1,0 +1,263 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Jobs;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace RobbieCraft.World
+{
+    /// <summary>
+    /// Burst-compiled job that performs greedy meshing on chunk voxel data to minimize triangle count.
+    /// </summary>
+    [BurstCompile]
+    public struct ChunkGreedyMesher : IJob
+    {
+        [ReadOnly]
+        public NativeArray<byte> Blocks;
+
+        /// <summary>
+        /// Block id that represents "air" and should not be rendered.
+        /// </summary>
+        public byte AirBlockId;
+
+        public NativeList<float3> Vertices;
+        public NativeList<int> Triangles;
+        public NativeList<float3> Normals;
+        public NativeList<float2> Uv;
+        public NativeArray<byte> MaskBuffer;
+
+        private static readonly int3[] Directions =
+        {
+            new int3( 0,  0,  1),
+            new int3( 0,  0, -1),
+            new int3( 0,  1,  0),
+            new int3( 0, -1,  0),
+            new int3( 1,  0,  0),
+            new int3(-1,  0,  0)
+        };
+
+        /// <summary>
+        /// Executes the greedy meshing algorithm.
+        /// </summary>
+        public void Execute()
+        {
+            // For each direction we compute a 2D mask and greedy merge rectangles.
+            for (int dirIndex = 0; dirIndex < Directions.Length; dirIndex++)
+            {
+                ProcessDirection(dirIndex);
+            }
+        }
+
+        private void ProcessDirection(int dirIndex)
+        {
+            int3 dir = Directions[dirIndex];
+
+            int a1, a2, b1, b2, c1, c2;
+
+            if (dirIndex < 2) // +/-Z
+            {
+                a1 = 0; a2 = ChunkConfig.ChunkSizeX;
+                b1 = 0; b2 = ChunkConfig.ChunkSizeY;
+                c1 = dirIndex == 0 ? ChunkConfig.ChunkSizeZ - 1 : 0;
+                c2 = c1 + (dirIndex == 0 ? 1 : -1);
+            }
+            else if (dirIndex < 4) // +/-Y
+            {
+                a1 = 0; a2 = ChunkConfig.ChunkSizeX;
+                b1 = 0; b2 = ChunkConfig.ChunkSizeZ;
+                c1 = dirIndex == 2 ? ChunkConfig.ChunkSizeY - 1 : 0;
+                c2 = c1 + (dirIndex == 2 ? 1 : -1);
+            }
+            else // +/-X
+            {
+                a1 = 0; a2 = ChunkConfig.ChunkSizeZ;
+                b1 = 0; b2 = ChunkConfig.ChunkSizeY;
+                c1 = dirIndex == 4 ? ChunkConfig.ChunkSizeX - 1 : 0;
+                c2 = c1 + (dirIndex == 4 ? 1 : -1);
+            }
+
+            int uSize = a2 - a1;
+            int vSize = b2 - b1;
+            int maskLength = uSize * vSize;
+            if (MaskBuffer.Length < maskLength)
+            {
+                throw new System.InvalidOperationException("Mask buffer is too small for greedy meshing.");
+            }
+
+            for (int slice = 0; slice < ChunkConfig.ChunkSizeX + ChunkConfig.ChunkSizeY + ChunkConfig.ChunkSizeZ; slice++)
+            {
+                int c = c1 + slice * (c2 - c1);
+                if (c < 0 || c >= (dirIndex < 2 ? ChunkConfig.ChunkSizeZ : dirIndex < 4 ? ChunkConfig.ChunkSizeY : ChunkConfig.ChunkSizeX))
+                {
+                    break;
+                }
+
+                for (int i = 0; i < maskLength; i++)
+                {
+                    MaskBuffer[i] = 0;
+                }
+
+                for (int v = b1; v < b2; v++)
+                {
+                    for (int u = a1; u < a2; u++)
+                    {
+                        int3 voxel = dirIndex switch
+                        {
+                            0 => new int3(u, v, c),
+                            1 => new int3(u, v, c),
+                            2 => new int3(u, c, v),
+                            3 => new int3(u, c, v),
+                            4 => new int3(c, v, u),
+                            _ => new int3(c, v, u)
+                        };
+
+                        int3 neighbor = voxel + dir;
+                        bool currentSolid = IsSolid(voxel.x, voxel.y, voxel.z);
+                        bool neighborSolid = IsSolid(neighbor.x, neighbor.y, neighbor.z);
+
+                        int maskIndex = (v - b1) * uSize + (u - a1);
+                        MaskBuffer[maskIndex] = (byte)((currentSolid && !neighborSolid) ? GetBlock(voxel.x, voxel.y, voxel.z) : (byte)0);
+                    }
+                }
+
+                // Greedy merge rectangles within mask
+                for (int v = 0; v < vSize; v++)
+                {
+                    for (int u = 0; u < uSize; )
+                    {
+                        byte block = MaskBuffer[v * uSize + u];
+                        if (block == 0)
+                        {
+                            u++;
+                            continue;
+                        }
+
+                        int width = 1;
+                        while (u + width < uSize && MaskBuffer[v * uSize + (u + width)] == block)
+                        {
+                            width++;
+                        }
+
+                        int height = 1;
+                        bool done = false;
+                        while (v + height < vSize && !done)
+                        {
+                            for (int k = 0; k < width; k++)
+                            {
+                                if (MaskBuffer[(v + height) * uSize + (u + k)] != block)
+                                {
+                                    done = true;
+                                    break;
+                                }
+                            }
+
+                            if (!done)
+                            {
+                                height++;
+                            }
+                        }
+
+                        // Add face
+                        AddFace(dirIndex, u + a1, v + b1, c, width, height, block);
+
+                        // Clear mask region
+                        for (int y = 0; y < height; y++)
+                        {
+                            for (int x = 0; x < width; x++)
+                            {
+                                MaskBuffer[(v + y) * uSize + (u + x)] = 0;
+                            }
+                        }
+
+                        u += width;
+                    }
+                }
+            }
+        }
+
+        private bool IsSolid(int x, int y, int z)
+        {
+            if (!InsideChunk(x, y, z))
+            {
+                return false;
+            }
+
+            return GetBlock(x, y, z) != AirBlockId;
+        }
+
+        private static bool InsideChunk(int x, int y, int z)
+        {
+            return x >= 0 && x < ChunkConfig.ChunkSizeX &&
+                   y >= 0 && y < ChunkConfig.ChunkSizeY &&
+                   z >= 0 && z < ChunkConfig.ChunkSizeZ;
+        }
+
+        private byte GetBlock(int x, int y, int z) => Blocks[ChunkConfig.ToIndex(x, y, z)];
+
+        private void AddFace(int dirIndex, int u, int v, int c, int width, int height, byte blockId)
+        {
+            float3 normal = Directions[dirIndex];
+            int vertexStartIndex = Vertices.Length;
+
+            float3 basePosition;
+            float3 uAxis;
+            float3 vAxis;
+
+            switch (dirIndex)
+            {
+                case 0: // +Z
+                    basePosition = new float3(u, v, c + 1);
+                    uAxis = new float3(width, 0, 0);
+                    vAxis = new float3(0, height, 0);
+                    break;
+                case 1: // -Z
+                    basePosition = new float3(u + width, v, c);
+                    uAxis = new float3(-width, 0, 0);
+                    vAxis = new float3(0, height, 0);
+                    break;
+                case 2: // +Y
+                    basePosition = new float3(u, c + 1, v);
+                    uAxis = new float3(width, 0, 0);
+                    vAxis = new float3(0, 0, height);
+                    break;
+                case 3: // -Y
+                    basePosition = new float3(u, c, v + height);
+                    uAxis = new float3(width, 0, 0);
+                    vAxis = new float3(0, 0, -height);
+                    break;
+                case 4: // +X
+                    basePosition = new float3(c + 1, v, u);
+                    uAxis = new float3(0, 0, width);
+                    vAxis = new float3(0, height, 0);
+                    break;
+                default: // -X
+                    basePosition = new float3(c, v, u + width);
+                    uAxis = new float3(0, 0, -width);
+                    vAxis = new float3(0, height, 0);
+                    break;
+            }
+
+            Vertices.Add(basePosition);
+            Vertices.Add(basePosition + uAxis);
+            Vertices.Add(basePosition + vAxis);
+            Vertices.Add(basePosition + uAxis + vAxis);
+
+            Triangles.Add(vertexStartIndex + 0);
+            Triangles.Add(vertexStartIndex + 2);
+            Triangles.Add(vertexStartIndex + 1);
+            Triangles.Add(vertexStartIndex + 2);
+            Triangles.Add(vertexStartIndex + 3);
+            Triangles.Add(vertexStartIndex + 1);
+
+            Normals.Add(normal);
+            Normals.Add(normal);
+            Normals.Add(normal);
+            Normals.Add(normal);
+
+            Uv.Add(new float2(0, 0));
+            Uv.Add(new float2(width, 0));
+            Uv.Add(new float2(0, height));
+            Uv.Add(new float2(width, height));
+        }
+    }
+}

--- a/Assets/Scripts/World/ChunkMeshData.cs
+++ b/Assets/Scripts/World/ChunkMeshData.cs
@@ -1,0 +1,32 @@
+using Unity.Collections;
+using Unity.Mathematics;
+
+namespace RobbieCraft.World
+{
+    /// <summary>
+    /// Helper container that owns the native lists produced by the greedy mesher.
+    /// </summary>
+    public struct ChunkMeshData
+    {
+        public NativeList<float3> Vertices;
+        public NativeList<int> Triangles;
+        public NativeList<float3> Normals;
+        public NativeList<float2> Uv;
+
+        public ChunkMeshData(Allocator allocator)
+        {
+            Vertices = new NativeList<float3>(allocator);
+            Triangles = new NativeList<int>(allocator);
+            Normals = new NativeList<float3>(allocator);
+            Uv = new NativeList<float2>(allocator);
+        }
+
+        public void Dispose()
+        {
+            if (Vertices.IsCreated) Vertices.Dispose();
+            if (Triangles.IsCreated) Triangles.Dispose();
+            if (Normals.IsCreated) Normals.Dispose();
+            if (Uv.IsCreated) Uv.Dispose();
+        }
+    }
+}

--- a/Assets/Scripts/World/WorldChunk.cs
+++ b/Assets/Scripts/World/WorldChunk.cs
@@ -1,0 +1,268 @@
+using System;
+using Unity.Collections;
+using Unity.Jobs;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace RobbieCraft.World
+{
+    /// <summary>
+    /// Runtime component that owns the mesh and lifecycle of a single chunk instance.
+    /// </summary>
+    [RequireComponent(typeof(MeshFilter), typeof(MeshRenderer))]
+    public sealed class WorldChunk : MonoBehaviour
+    {
+        [SerializeField]
+        private MeshCollider meshCollider;
+
+        private Mesh _mesh;
+        private ChunkData _chunkData;
+        private JobHandle _generationHandle;
+        private JobHandle _meshHandle;
+        private bool _generationScheduled;
+        private bool _meshScheduled;
+        private bool _meshRequested;
+        private ChunkMeshData _meshData;
+        private int _currentLodLevel = -1;
+        private NativeArray<byte> _maskBuffer;
+
+        /// <summary>
+        /// Coordinate of this chunk on the world grid.
+        /// </summary>
+        public ChunkCoordinate Coordinate { get; private set; }
+
+        /// <summary>
+        /// True when the chunk is waiting for background job completion.
+        /// </summary>
+        public bool IsBusy => _generationScheduled || _meshScheduled;
+
+        /// <summary>
+        /// Current level-of-detail that is displayed by this chunk mesh.
+        /// </summary>
+        public int CurrentLodLevel => _currentLodLevel;
+
+        /// <summary>
+        /// Schedules the asynchronous generation job for this chunk.
+        /// </summary>
+        public void ScheduleGeneration(ChunkCoordinate coordinate, ChunkGenerationJob job)
+        {
+            Coordinate = coordinate;
+            _chunkData ??= new ChunkData(Allocator.Persistent);
+            if (!_maskBuffer.IsCreated)
+            {
+                _maskBuffer = new NativeArray<byte>(ChunkConfig.ChunkSizeX * ChunkConfig.ChunkSizeY, Allocator.Persistent, NativeArrayOptions.ClearMemory);
+            }
+            NativeArray<byte> rawData = _chunkData.RawData;
+            job.Blocks = rawData;
+            _generationHandle = job.Schedule(rawData.Length, ChunkConfig.ChunkSizeX);
+            _generationScheduled = true;
+            _meshRequested = false;
+            _currentLodLevel = -1;
+            _meshScheduled = false;
+        }
+
+        /// <summary>
+        /// Marks the chunk to build a mesh as soon as generation completes.
+        /// </summary>
+        public void ScheduleMeshBuild(byte airBlockId, int lodLevel)
+        {
+            if (_currentLodLevel == lodLevel && !_meshRequested && !_meshScheduled)
+            {
+                return;
+            }
+
+            _pendingAirBlock = airBlockId;
+            _pendingLodLevel = lodLevel;
+
+            if (_generationScheduled)
+            {
+                _meshRequested = true;
+            }
+            else if (!_meshScheduled)
+            {
+                ScheduleMeshConstruction();
+            }
+        }
+
+        private void LateUpdate()
+        {
+            if (_meshRequested && _generationHandle.IsCompleted && !_meshScheduled)
+            {
+                FinalizeGeneration();
+            }
+
+            if (!_meshScheduled || !_meshHandle.IsCompleted)
+            {
+                return;
+            }
+
+            _meshHandle.Complete();
+            ApplyMesh();
+            _meshScheduled = false;
+            if (_meshData.Vertices.IsCreated)
+            {
+                _meshData.Dispose();
+            }
+            _currentLodLevel = _pendingLodLevel;
+        }
+
+        private byte _pendingAirBlock;
+        private int _pendingLodLevel;
+
+        private void FinalizeGeneration()
+        {
+            _generationHandle.Complete();
+            _generationScheduled = false;
+            _meshRequested = false;
+
+            ScheduleMeshConstruction();
+        }
+
+        private void ScheduleMeshConstruction()
+        {
+            _meshRequested = false;
+
+            if (_pendingLodLevel == 0)
+            {
+                _meshData = new ChunkMeshData(Allocator.TempJob);
+                var mesher = new ChunkGreedyMesher
+                {
+                    Blocks = _chunkData.RawData,
+                    AirBlockId = _pendingAirBlock,
+                    Vertices = _meshData.Vertices,
+                    Triangles = _meshData.Triangles,
+                    Normals = _meshData.Normals,
+                    Uv = _meshData.Uv,
+                    MaskBuffer = _maskBuffer
+                };
+
+                _meshHandle = mesher.Schedule();
+                _meshScheduled = true;
+            }
+            else
+            {
+                BuildLowDetailMesh(_pendingLodLevel);
+            }
+        }
+
+        private void BuildLowDetailMesh(int lodLevel)
+        {
+            int step = 1 << lodLevel;
+            var vertices = new System.Collections.Generic.List<Vector3>();
+            var normals = new System.Collections.Generic.List<Vector3>();
+            var uvs = new System.Collections.Generic.List<Vector2>();
+            var triangles = new System.Collections.Generic.List<int>();
+
+            NativeArray<byte> blocks = _chunkData.RawData;
+
+            for (int x = 0; x < ChunkConfig.ChunkSizeX; x += step)
+            {
+                for (int z = 0; z < ChunkConfig.ChunkSizeZ; z += step)
+                {
+                    int maxHeight = 0;
+                    for (int localX = 0; localX < step && x + localX < ChunkConfig.ChunkSizeX; localX++)
+                    {
+                        for (int localZ = 0; localZ < step && z + localZ < ChunkConfig.ChunkSizeZ; localZ++)
+                        {
+                            for (int y = ChunkConfig.ChunkSizeY - 1; y >= 0; y--)
+                            {
+                                if (blocks[ChunkConfig.ToIndex(x + localX, y, z + localZ)] != _pendingAirBlock)
+                                {
+                                    maxHeight = math.max(maxHeight, y + 1);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    float height = maxHeight;
+                    Vector3 basePos = new Vector3(x, height, z);
+                    int vertStart = vertices.Count;
+                    vertices.Add(basePos);
+                    vertices.Add(basePos + new Vector3(step, 0f, 0f));
+                    vertices.Add(basePos + new Vector3(0f, 0f, step));
+                    vertices.Add(basePos + new Vector3(step, 0f, step));
+
+                    triangles.Add(vertStart + 0);
+                    triangles.Add(vertStart + 2);
+                    triangles.Add(vertStart + 1);
+                    triangles.Add(vertStart + 2);
+                    triangles.Add(vertStart + 3);
+                    triangles.Add(vertStart + 1);
+
+                    Vector3 normal = Vector3.up;
+                    normals.Add(normal);
+                    normals.Add(normal);
+                    normals.Add(normal);
+                    normals.Add(normal);
+
+                    uvs.Add(new Vector2(0f, 0f));
+                    uvs.Add(new Vector2(1f, 0f));
+                    uvs.Add(new Vector2(0f, 1f));
+                    uvs.Add(new Vector2(1f, 1f));
+                }
+            }
+
+            ApplyMesh(vertices, normals, uvs, triangles);
+            _meshScheduled = false;
+            _currentLodLevel = lodLevel;
+        }
+
+        private void ApplyMesh(System.Collections.Generic.List<Vector3> vertices, System.Collections.Generic.List<Vector3> normals, System.Collections.Generic.List<Vector2> uvs, System.Collections.Generic.List<int> triangles)
+        {
+            _mesh ??= new Mesh { name = $"Chunk_{Coordinate.X}_{Coordinate.Z}" };
+            _mesh.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
+            _mesh.SetVertices(vertices);
+            _mesh.SetNormals(normals);
+            _mesh.SetUVs(0, uvs);
+            _mesh.SetTriangles(triangles, 0);
+            _mesh.RecalculateBounds();
+
+            GetComponent<MeshFilter>().sharedMesh = _mesh;
+            if (meshCollider != null)
+            {
+                meshCollider.sharedMesh = _mesh;
+            }
+        }
+
+        private void ApplyMesh()
+        {
+            _mesh ??= new Mesh { name = $"Chunk_{Coordinate.X}_{Coordinate.Z}" };
+            _mesh.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
+            _mesh.SetVertices(_meshData.Vertices.AsArray());
+            _mesh.SetNormals(_meshData.Normals.AsArray());
+            _mesh.SetUVs(0, _meshData.Uv.AsArray());
+            _mesh.SetTriangles(_meshData.Triangles.AsArray(), 0);
+            _mesh.RecalculateBounds();
+
+            GetComponent<MeshFilter>().sharedMesh = _mesh;
+            if (meshCollider != null)
+            {
+                meshCollider.sharedMesh = _mesh;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (_generationScheduled)
+            {
+                _generationHandle.Complete();
+            }
+
+            if (_meshScheduled)
+            {
+                _meshHandle.Complete();
+            }
+
+            _chunkData?.Dispose();
+            if (_meshData.Vertices.IsCreated)
+            {
+                _meshData.Dispose();
+            }
+            if (_maskBuffer.IsCreated)
+            {
+                _maskBuffer.Dispose();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/World/WorldManager.cs
+++ b/Assets/Scripts/World/WorldManager.cs
@@ -1,0 +1,209 @@
+using System.Collections.Generic;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace RobbieCraft.World
+{
+    /// <summary>
+    /// Manages chunk lifecycle, streaming, and visibility around the active player.
+    /// </summary>
+    public sealed class WorldManager : MonoBehaviour
+    {
+        [Header("References")]
+        [SerializeField]
+        private Transform player;
+
+        [SerializeField]
+        private WorldChunk chunkPrefab;
+
+        [Header("Generation Settings")]
+        [SerializeField, Range(1, 8)]
+        private int viewDistance = 4;
+
+        [SerializeField]
+        private float baseHeight = 32f;
+
+        [SerializeField]
+        private float noiseScale = 0.05f;
+
+        [SerializeField]
+        private float heightAmplitude = 12f;
+
+        [Header("Blocks")]
+        [SerializeField]
+        private byte groundBlockId = 1;
+
+        [SerializeField]
+        private byte airBlockId = 0;
+
+        private readonly Dictionary<ChunkCoordinate, WorldChunk> _loadedChunks = new();
+        private readonly Queue<WorldChunk> _chunkPool = new();
+        private Camera _mainCamera;
+        private Plane[] _frustumPlanes = new Plane[6];
+
+        private void Awake()
+        {
+            _mainCamera = Camera.main;
+        }
+
+        private void Start()
+        {
+            EnsureSpawnArea();
+        }
+
+        private void Update()
+        {
+            if (player == null || chunkPrefab == null)
+            {
+                return;
+            }
+
+            ChunkCoordinate center = WorldToChunk(player.position);
+            UpdateVisibleChunks(center);
+            UpdateChunkLods(center);
+            UpdateFrustumCulling();
+        }
+
+        private void EnsureSpawnArea()
+        {
+            // Preload a flat spawn area centered at origin
+            for (int x = -ChunkConfig.SpawnAreaSize; x < ChunkConfig.SpawnAreaSize; x++)
+            {
+                for (int z = -ChunkConfig.SpawnAreaSize; z < ChunkConfig.SpawnAreaSize; z++)
+                {
+                    ChunkCoordinate coord = new ChunkCoordinate(x, z);
+                    if (_loadedChunks.ContainsKey(coord))
+                    {
+                        continue;
+                    }
+
+                    var chunk = InstantiateChunk(coord);
+                    ScheduleChunkBuild(chunk, coord, flat: true, lodLevel: 0);
+                }
+            }
+        }
+
+        private void UpdateVisibleChunks(ChunkCoordinate center)
+        {
+            List<ChunkCoordinate> needed = new();
+
+            for (int x = -viewDistance; x <= viewDistance; x++)
+            {
+                for (int z = -viewDistance; z <= viewDistance; z++)
+                {
+                    ChunkCoordinate coord = new ChunkCoordinate(center.X + x, center.Z + z);
+                    needed.Add(coord);
+                    if (!_loadedChunks.ContainsKey(coord))
+                    {
+                        var chunk = InstantiateChunk(coord);
+                        bool flat = math.abs(coord.X) < ChunkConfig.SpawnAreaSize && math.abs(coord.Z) < ChunkConfig.SpawnAreaSize;
+                        int lod = DetermineLodLevel(center, coord);
+                        ScheduleChunkBuild(chunk, coord, flat, lod);
+                    }
+                }
+            }
+
+            // Despawn chunks that are no longer needed.
+            List<ChunkCoordinate> toRemove = new();
+            foreach (var kvp in _loadedChunks)
+            {
+                if (!needed.Contains(kvp.Key) && !kvp.Value.IsBusy)
+                {
+                    toRemove.Add(kvp.Key);
+                }
+            }
+
+            foreach (ChunkCoordinate coord in toRemove)
+            {
+                var chunk = _loadedChunks[coord];
+                _loadedChunks.Remove(coord);
+                chunk.gameObject.SetActive(false);
+                _chunkPool.Enqueue(chunk);
+            }
+        }
+
+        private void UpdateChunkLods(ChunkCoordinate center)
+        {
+            foreach (var kvp in _loadedChunks)
+            {
+                int desiredLod = DetermineLodLevel(center, kvp.Key);
+                if (kvp.Value.CurrentLodLevel != desiredLod && !kvp.Value.IsBusy)
+                {
+                    kvp.Value.ScheduleMeshBuild(airBlockId, desiredLod);
+                }
+            }
+        }
+
+        private void UpdateFrustumCulling()
+        {
+            if (_mainCamera == null)
+            {
+                _mainCamera = Camera.main;
+                if (_mainCamera == null)
+                {
+                    return;
+                }
+            }
+
+            GeometryUtility.CalculateFrustumPlanes(_mainCamera, _frustumPlanes);
+
+            foreach (WorldChunk chunk in _loadedChunks.Values)
+            {
+                Bounds chunkBounds = new Bounds(chunk.transform.position + new Vector3(ChunkConfig.ChunkSizeX, ChunkConfig.ChunkSizeY / 2f, ChunkConfig.ChunkSizeZ) * 0.5f,
+                    new Vector3(ChunkConfig.ChunkSizeX, ChunkConfig.ChunkSizeY, ChunkConfig.ChunkSizeZ));
+                bool visible = GeometryUtility.TestPlanesAABB(_frustumPlanes, chunkBounds);
+                chunk.gameObject.SetActive(visible);
+            }
+        }
+
+        private WorldChunk InstantiateChunk(ChunkCoordinate coord)
+        {
+            WorldChunk chunk = _chunkPool.Count > 0 ? _chunkPool.Dequeue() : Instantiate(chunkPrefab);
+            chunk.gameObject.name = $"Chunk_{coord.X}_{coord.Z}";
+            chunk.transform.SetParent(transform, false);
+            chunk.transform.position = new Vector3(coord.X * ChunkConfig.ChunkSizeX, 0f, coord.Z * ChunkConfig.ChunkSizeZ);
+            chunk.gameObject.SetActive(true);
+            _loadedChunks[coord] = chunk;
+            return chunk;
+        }
+
+        private void ScheduleChunkBuild(WorldChunk chunk, ChunkCoordinate coord, bool flat, int lodLevel)
+        {
+            var job = new ChunkGenerationJob
+            {
+                Coordinate = coord,
+                BaseHeight = flat ? baseHeight : baseHeight,
+                NoiseScale = flat ? 0f : noiseScale,
+                HeightAmplitude = flat ? 0f : heightAmplitude,
+                GroundBlockId = groundBlockId,
+                AirBlockId = airBlockId
+            };
+
+            chunk.ScheduleGeneration(coord, job);
+            chunk.ScheduleMeshBuild(airBlockId, lodLevel);
+        }
+
+        private static ChunkCoordinate WorldToChunk(Vector3 worldPosition)
+        {
+            int x = Mathf.FloorToInt(worldPosition.x / ChunkConfig.ChunkSizeX);
+            int z = Mathf.FloorToInt(worldPosition.z / ChunkConfig.ChunkSizeZ);
+            return new ChunkCoordinate(x, z);
+        }
+
+        private int DetermineLodLevel(ChunkCoordinate center, ChunkCoordinate target)
+        {
+            int distance = Mathf.Max(Mathf.Abs(center.X - target.X), Mathf.Abs(center.Z - target.Z));
+            if (distance <= 1)
+            {
+                return 0;
+            }
+
+            if (distance <= 3)
+            {
+                return 1;
+            }
+
+            return 2;
+        }
+    }
+}

--- a/checklist.md
+++ b/checklist.md
@@ -4,15 +4,15 @@ Phase 1 – Core Foundations (Week 1)
 
 ✅ World & Chunk System
 
-[ ] Implement chunk grid (16×128×16).
+[x] Implement chunk grid (16×128×16).
 
-[ ] Add greedy meshing algorithm.
+[x] Add greedy meshing algorithm.
 
-[ ] Async chunk generation with Unity Jobs + Burst.
+[x] Async chunk generation with Unity Jobs + Burst.
 
-[ ] Frustum culling + LOD system.
+[x] Frustum culling + LOD system.
 
-[ ] Flat 32×32 safe spawn area.
+[x] Flat 32×32 safe spawn area.
 
 
 ✅ Block & Registry


### PR DESCRIPTION
## Summary
- add voxel chunk configuration helpers and data containers for the RobbieCraft world grid
- implement Burst-powered chunk generation and greedy meshing jobs with reusable native buffers
- create world streaming manager with async chunk lifecycle, LOD switching, frustum culling, and a safe flat spawn area, updating the delivery checklist

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68da9d5704e8832a842ecd33964c3710