### PR TITLE
Add block registry and tinting infrastructure

### DIFF
--- a/Assets/ScriptableObjects.meta
+++ b/Assets/ScriptableObjects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1b99adf6b77643d59db9bc6685d6f03c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/BlockMaterialAtlas.asset
+++ b/Assets/ScriptableObjects/BlockMaterialAtlas.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86c289f26c064e079c61a19cb121ad77, type: 3}
+  m_Name: BlockMaterialAtlas
+  m_EditorClassIdentifier: 
+  atlasTexture: {fileID: 0}
+  atlasSize: {x: 2048, y: 2048}
+  tileSize: {x: 128, y: 128}
+  tilePadding: 4

--- a/Assets/ScriptableObjects/BlockMaterialAtlas.asset.meta
+++ b/Assets/ScriptableObjects/BlockMaterialAtlas.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4c2c7d1db7c2483d9e2a5c38e5ff2b5e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/BlockTypeRegistry.asset
+++ b/Assets/ScriptableObjects/BlockTypeRegistry.asset
@@ -1,0 +1,72 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d9eaf1a3ddf4f8c8bf5d61d9d7914ce, type: 3}
+  m_Name: BlockTypeRegistry
+  m_EditorClassIdentifier: 
+  materialAtlas: {fileID: 11400000, guid: 4c2c7d1db7c2483d9e2a5c38e5ff2b5e, type: 2}
+  blockTypes:
+  - id: 0
+    displayName: Air
+    isSolid: 0
+    durability: 0
+    breakTime: 0.1
+    baseTint: {r: 0, g: 0, b: 0, a: 0}
+    supportsTinting: 0
+    atlasTile: {x: 0, y: 0}
+  - id: 1
+    displayName: Grass
+    isSolid: 1
+    durability: 12
+    breakTime: 0.8
+    baseTint: {r: 0.45490196, g: 0.7254902, b: 0.32941177, a: 1}
+    supportsTinting: 1
+    atlasTile: {x: 0, y: 1}
+  - id: 2
+    displayName: Dirt
+    isSolid: 1
+    durability: 18
+    breakTime: 1.2
+    baseTint: {r: 0.5254902, g: 0.3764706, b: 0.2627451, a: 1}
+    supportsTinting: 0
+    atlasTile: {x: 1, y: 1}
+  - id: 3
+    displayName: Stone
+    isSolid: 1
+    durability: 30
+    breakTime: 2.5
+    baseTint: {r: 0.47058824, g: 0.47058824, b: 0.47058824, a: 1}
+    supportsTinting: 0
+    atlasTile: {x: 2, y: 1}
+  - id: 10
+    displayName: Candy
+    isSolid: 1
+    durability: 10
+    breakTime: 0.6
+    baseTint: {r: 1, g: 0.45490196, b: 0.7372549, a: 1}
+    supportsTinting: 1
+    atlasTile: {x: 0, y: 2}
+  - id: 11
+    displayName: Robot
+    isSolid: 1
+    durability: 35
+    breakTime: 2
+    baseTint: {r: 0.7058824, g: 0.76862746, b: 0.8235294, a: 1}
+    supportsTinting: 0
+    atlasTile: {x: 1, y: 2}
+  - id: 12
+    displayName: Ice
+    isSolid: 1
+    durability: 16
+    breakTime: 1.4
+    baseTint: {r: 0.627451, g: 0.8627451, b: 1, a: 0.78431374}
+    supportsTinting: 1
+    atlasTile: {x: 2, y: 2}

--- a/Assets/ScriptableObjects/BlockTypeRegistry.asset.meta
+++ b/Assets/ScriptableObjects/BlockTypeRegistry.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3a588953e07d41caa1b24a6c00582b24
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Blocks.meta
+++ b/Assets/Scripts/Blocks.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4b7f2221a7034e5a8e03eb17e7f077af
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Blocks/BlockMaterialAtlas.cs
+++ b/Assets/Scripts/Blocks/BlockMaterialAtlas.cs
@@ -1,0 +1,83 @@
+using UnityEngine;
+
+namespace RobbieCraft.Blocks
+{
+    /// <summary>
+    /// Describes the shared texture atlas used by voxel blocks.
+    /// Stores UV layout information so runtime systems can map block tiles.
+    /// </summary>
+    [CreateAssetMenu(fileName = "BlockMaterialAtlas", menuName = "RobbieCraft/Blocks/Material Atlas")]
+    public sealed class BlockMaterialAtlas : ScriptableObject
+    {
+        [SerializeField]
+        private Texture2D atlasTexture;
+
+        [SerializeField]
+        private Vector2Int atlasSize = new Vector2Int(2048, 2048);
+
+        [SerializeField]
+        private Vector2Int tileSize = new Vector2Int(128, 128);
+
+        [SerializeField, Tooltip("Optional padding between tiles in pixels to avoid bleeding when sampling mipmaps.")]
+        private int tilePadding = 4;
+
+        /// <summary>
+        /// Underlying texture for the atlas. Can be null in editor builds while content is authored.
+        /// </summary>
+        public Texture2D AtlasTexture => atlasTexture;
+
+        /// <summary>
+        /// Pixel dimensions of the atlas. Falls back to the assigned texture size if available.
+        /// </summary>
+        public Vector2Int AtlasSize => atlasTexture != null ? new Vector2Int(atlasTexture.width, atlasTexture.height) : atlasSize;
+
+        /// <summary>
+        /// Pixel size for each tile entry in the atlas.
+        /// </summary>
+        public Vector2Int TileSize => tileSize;
+
+        /// <summary>
+        /// Pixel padding between atlas tiles.
+        /// </summary>
+        public int TilePadding => Mathf.Max(0, tilePadding);
+
+        /// <summary>
+        /// Calculates the UV rect for a tile coordinate within the atlas.
+        /// </summary>
+        /// <param name="tileIndex">Zero-based tile coordinate (x = column, y = row).</param>
+        /// <returns>UV rect in normalized 0-1 space.</returns>
+        public Rect GetTileUv(Vector2Int tileIndex)
+        {
+            Vector2Int size = AtlasSize;
+            if (tileSize.x <= 0 || tileSize.y <= 0 || size.x <= 0 || size.y <= 0)
+            {
+                return new Rect(0f, 0f, 1f, 1f);
+            }
+
+            Vector2 tileSizeWithPadding = new Vector2(tileSize.x + TilePadding, tileSize.y + TilePadding);
+            Vector2 uvScale = new Vector2(tileSize.x / (float)size.x, tileSize.y / (float)size.y);
+            Vector2 uvPadding = new Vector2(TilePadding / (float)size.x, TilePadding / (float)size.y);
+
+            Vector2 uvMin = new Vector2(
+                tileIndex.x * tileSizeWithPadding.x / size.x,
+                tileIndex.y * tileSizeWithPadding.y / size.y);
+
+            return new Rect(uvMin.x + uvPadding.x * 0.5f, uvMin.y + uvPadding.y * 0.5f, uvScale.x - uvPadding.x, uvScale.y - uvPadding.y);
+        }
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            atlasSize.x = Mathf.Max(1, atlasSize.x);
+            atlasSize.y = Mathf.Max(1, atlasSize.y);
+            tileSize.x = Mathf.Max(1, tileSize.x);
+            tileSize.y = Mathf.Max(1, tileSize.y);
+
+            if (atlasTexture != null && (atlasTexture.width != 2048 || atlasTexture.height != 2048))
+            {
+                Debug.LogWarning($"BlockMaterialAtlas '{name}' expects a 2048x2048 texture for optimal sampling.");
+            }
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/Blocks/BlockMaterialAtlas.cs.meta
+++ b/Assets/Scripts/Blocks/BlockMaterialAtlas.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86c289f26c064e079c61a19cb121ad77
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Blocks/BlockTintSystem.cs
+++ b/Assets/Scripts/Blocks/BlockTintSystem.cs
@@ -1,0 +1,55 @@
+using RobbieCraft.World;
+using UnityEngine;
+
+namespace RobbieCraft.Blocks
+{
+    /// <summary>
+    /// Utility helpers for applying and clearing per-voxel tint colors.
+    /// Designed for use by the Rainbow Painter tool and similar systems.
+    /// </summary>
+    public static class BlockTintSystem
+    {
+        /// <summary>
+        /// Applies a tint to a specific voxel inside a chunk.
+        /// </summary>
+        /// <param name="chunk">Target chunk.</param>
+        /// <param name="x">Local block X coordinate.</param>
+        /// <param name="y">Local block Y coordinate.</param>
+        /// <param name="z">Local block Z coordinate.</param>
+        /// <param name="color">Desired tint color.</param>
+        /// <returns>True if the tint was applied, false if the block does not support tinting.</returns>
+        public static bool ApplyTint(WorldChunk chunk, int x, int y, int z, Color color)
+        {
+            if (chunk == null)
+            {
+                return false;
+            }
+
+            if (!chunk.TryGetBlock(x, y, z, out byte blockId))
+            {
+                return false;
+            }
+
+            if (!chunk.SupportsTint(blockId))
+            {
+                return false;
+            }
+
+            chunk.SetBlockTint(x, y, z, color);
+            return true;
+        }
+
+        /// <summary>
+        /// Clears any tint previously applied to the voxel at the given position.
+        /// </summary>
+        public static void ClearTint(WorldChunk chunk, int x, int y, int z)
+        {
+            if (chunk == null)
+            {
+                return;
+            }
+
+            chunk.ClearBlockTint(x, y, z);
+        }
+    }
+}

--- a/Assets/Scripts/Blocks/BlockTintSystem.cs.meta
+++ b/Assets/Scripts/Blocks/BlockTintSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 57b5a116fda04db2aac07eb01ab3ac5f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Blocks/BlockTypeRegistry.cs
+++ b/Assets/Scripts/Blocks/BlockTypeRegistry.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using Unity.Collections;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace RobbieCraft.Blocks
+{
+    /// <summary>
+    /// Serializable description of a single block type.
+    /// </summary>
+    [Serializable]
+    public sealed class BlockTypeDefinition
+    {
+        [SerializeField]
+        protected internal byte id;
+
+        [SerializeField]
+        protected internal string displayName = "New Block";
+
+        [SerializeField]
+        protected internal bool isSolid = true;
+
+        [SerializeField, Tooltip("Maximum durability (hit points) before the block breaks.")]
+        protected internal float durability = 10f;
+
+        [SerializeField, Tooltip("Default time (seconds) it takes to break the block with standard tools.")]
+        protected internal float breakTime = 1f;
+
+        [SerializeField, Tooltip("Base tint color displayed on the voxel faces.")]
+        protected internal Color baseTint = Color.white;
+
+        [SerializeField, Tooltip("True if the block can be recolored by tinting tools (Rainbow Painter).")]
+        protected internal bool supportsTinting = false;
+
+        [SerializeField, Tooltip("Tile coordinate within the shared block material atlas.")]
+        protected internal Vector2Int atlasTile = Vector2Int.zero;
+
+        public byte Id => id;
+        public string DisplayName => displayName;
+        public bool IsSolid => isSolid;
+        public float Durability => math.max(0f, durability);
+        public float BreakTime => math.max(0.01f, breakTime);
+        public Color BaseTint => baseTint;
+        public bool SupportsTinting => supportsTinting;
+        public Vector2Int AtlasTile => atlasTile;
+
+        /// <summary>
+        /// Converts the definition into the runtime visual info used by Burst jobs.
+        /// </summary>
+        internal BlockVisualInfo ToVisualInfo(BlockMaterialAtlas atlas)
+        {
+            Rect uv = atlas != null ? atlas.GetTileUv(atlasTile) : new Rect(0f, 0f, 1f, 1f);
+            var info = new BlockVisualInfo
+            {
+                BaseColor = baseTint,
+                UvMin = new float2(uv.xMin, uv.yMin),
+                UvSize = new float2(uv.width, uv.height),
+                Flags = supportsTinting ? BlockVisualFlags.SupportsTint : BlockVisualFlags.None
+            };
+            return info;
+        }
+    }
+
+    /// <summary>
+    /// Runtime data passed to Burst jobs for rendering information.
+    /// </summary>
+    public struct BlockVisualInfo
+    {
+        public Color32 BaseColor;
+        public float2 UvMin;
+        public float2 UvSize;
+        public BlockVisualFlags Flags;
+        private byte _padding0;
+        private byte _padding1;
+        private byte _padding2;
+    }
+
+    [Flags]
+    public enum BlockVisualFlags : byte
+    {
+        None = 0,
+        SupportsTint = 1 << 0
+    }
+
+    /// <summary>
+    /// Scriptable object registry containing all block definitions for the game.
+    /// </summary>
+    [CreateAssetMenu(fileName = "BlockTypeRegistry", menuName = "RobbieCraft/Blocks/Registry")]
+    public sealed class BlockTypeRegistry : ScriptableObject
+    {
+        [SerializeField]
+        private BlockMaterialAtlas materialAtlas;
+
+        [SerializeField]
+        private List<BlockTypeDefinition> blockTypes = new();
+
+        private readonly Dictionary<byte, BlockTypeDefinition> _lookup = new();
+
+        /// <summary>
+        /// Shared atlas information used by voxel materials.
+        /// </summary>
+        public BlockMaterialAtlas MaterialAtlas => materialAtlas;
+
+        /// <summary>
+        /// Provides read-only access to the block definitions.
+        /// </summary>
+        public IReadOnlyList<BlockTypeDefinition> BlockTypes => blockTypes;
+
+        private void OnEnable()
+        {
+            BuildLookup();
+        }
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            BuildLookup();
+        }
+#endif
+
+        /// <summary>
+        /// Retrieves a block definition by id.
+        /// </summary>
+        public bool TryGetDefinition(byte blockId, out BlockTypeDefinition definition)
+        {
+            return _lookup.TryGetValue(blockId, out definition);
+        }
+
+        /// <summary>
+        /// Gets the durability for a given block id.
+        /// </summary>
+        public float GetDurability(byte blockId)
+        {
+            return _lookup.TryGetValue(blockId, out BlockTypeDefinition def) ? def.Durability : 0f;
+        }
+
+        /// <summary>
+        /// Gets the base break time for a given block id.
+        /// </summary>
+        public float GetBreakTime(byte blockId)
+        {
+            return _lookup.TryGetValue(blockId, out BlockTypeDefinition def) ? def.BreakTime : 0f;
+        }
+
+        /// <summary>
+        /// Returns whether a block id supports rainbow tinting.
+        /// </summary>
+        public bool SupportsTinting(byte blockId)
+        {
+            return _lookup.TryGetValue(blockId, out BlockTypeDefinition def) && def.SupportsTinting;
+        }
+
+        /// <summary>
+        /// Builds the runtime visual information used by the greedy mesher.
+        /// The caller is responsible for disposing the returned native array.
+        /// </summary>
+        public NativeArray<BlockVisualInfo> BuildVisualInfo(Allocator allocator)
+        {
+            int maxId = 0;
+            foreach (BlockTypeDefinition def in blockTypes)
+            {
+                maxId = Mathf.Max(maxId, def.Id);
+            }
+
+            var array = new NativeArray<BlockVisualInfo>(maxId + 1, allocator, NativeArrayOptions.ClearMemory);
+            foreach (BlockTypeDefinition def in blockTypes)
+            {
+                array[def.Id] = def.ToVisualInfo(materialAtlas);
+            }
+
+            return array;
+        }
+
+        /// <summary>
+        /// Attempts to resolve a block id using its display name.
+        /// </summary>
+        public bool TryGetBlockId(string displayName, out byte blockId)
+        {
+            foreach (BlockTypeDefinition def in blockTypes)
+            {
+                if (string.Equals(def.DisplayName, displayName, StringComparison.OrdinalIgnoreCase))
+                {
+                    blockId = def.Id;
+                    return true;
+                }
+            }
+
+            blockId = 0;
+            return false;
+        }
+
+        private void BuildLookup()
+        {
+            _lookup.Clear();
+            if (blockTypes == null)
+            {
+                blockTypes = new List<BlockTypeDefinition>();
+            }
+
+            foreach (BlockTypeDefinition def in blockTypes)
+            {
+                if (_lookup.ContainsKey(def.Id))
+                {
+                    Debug.LogWarning($"Duplicate block id {def.Id} detected in {name}. Only the first entry will be used.");
+                    continue;
+                }
+
+                _lookup.Add(def.Id, def);
+            }
+        }
+
+#if UNITY_EDITOR
+        [ContextMenu("Populate Default Blocks")]
+        private void PopulateDefaults()
+        {
+            blockTypes = new List<BlockTypeDefinition>
+            {
+                CreateBlock(0, "Air", false, 0f, 0f, Color.clear, false, new Vector2Int(0, 0)),
+                CreateBlock(1, "Grass", true, 12f, 0.8f, new Color32(116, 185, 84, 255), true, new Vector2Int(0, 1)),
+                CreateBlock(2, "Dirt", true, 18f, 1.2f, new Color32(134, 96, 67, 255), false, new Vector2Int(1, 1)),
+                CreateBlock(3, "Stone", true, 30f, 2.5f, new Color32(120, 120, 120, 255), false, new Vector2Int(2, 1)),
+                CreateBlock(10, "Candy", true, 10f, 0.6f, new Color32(255, 116, 188, 255), true, new Vector2Int(0, 2)),
+                CreateBlock(11, "Robot", true, 35f, 2.0f, new Color32(180, 196, 210, 255), false, new Vector2Int(1, 2)),
+                CreateBlock(12, "Ice", true, 16f, 1.4f, new Color32(160, 220, 255, 200), true, new Vector2Int(2, 2))
+            };
+            BuildLookup();
+        }
+
+        private static BlockTypeDefinition CreateBlock(byte id, string name, bool solid, float durability, float breakTime, Color tint, bool tintable, Vector2Int tile)
+        {
+            return new BlockTypeDefinitionAccessor(id, name, solid, durability, breakTime, tint, tintable, tile);
+        }
+
+        /// <summary>
+        /// Helper class used to instantiate definitions with constructor-style syntax inside the editor-only context menu.
+        /// </summary>
+        private sealed class BlockTypeDefinitionAccessor : BlockTypeDefinition
+        {
+            public BlockTypeDefinitionAccessor(byte id, string displayName, bool isSolid, float durability, float breakTime, Color baseTint, bool supportsTinting, Vector2Int atlasTile)
+            {
+                this.id = id;
+                this.displayName = displayName;
+                this.isSolid = isSolid;
+                this.durability = durability;
+                this.breakTime = breakTime;
+                this.baseTint = baseTint;
+                this.supportsTinting = supportsTinting;
+                this.atlasTile = atlasTile;
+            }
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/Blocks/BlockTypeRegistry.cs.meta
+++ b/Assets/Scripts/Blocks/BlockTypeRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d9eaf1a3ddf4f8c8bf5d61d9d7914ce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/World/ChunkData.cs
+++ b/Assets/Scripts/World/ChunkData.cs
@@ -1,5 +1,6 @@
 using System;
 using Unity.Collections;
+using UnityEngine;
 
 namespace RobbieCraft.World
 {
@@ -9,6 +10,7 @@ namespace RobbieCraft.World
     public sealed class ChunkData : IDisposable
     {
         private NativeArray<byte> _blocks;
+        private NativeArray<Color32> _tints;
 
         /// <summary>
         /// Creates a new chunk data container with native storage.
@@ -16,6 +18,7 @@ namespace RobbieCraft.World
         public ChunkData(Allocator allocator)
         {
             _blocks = new NativeArray<byte>(ChunkConfig.BlocksPerChunk, allocator, NativeArrayOptions.ClearMemory);
+            _tints = new NativeArray<Color32>(ChunkConfig.BlocksPerChunk, allocator, NativeArrayOptions.ClearMemory);
         }
 
         /// <summary>
@@ -33,6 +36,11 @@ namespace RobbieCraft.World
         public NativeArray<byte> RawData => _blocks;
 
         /// <summary>
+        /// Provides raw access to tint override data. Alpha of zero indicates no tint.
+        /// </summary>
+        public NativeArray<Color32> RawTints => _tints;
+
+        /// <summary>
         /// Fills the entire chunk with a single block type.
         /// </summary>
         public void Fill(byte blockId)
@@ -40,6 +48,37 @@ namespace RobbieCraft.World
             for (int i = 0; i < _blocks.Length; i++)
             {
                 _blocks[i] = blockId;
+                _tints[i] = default;
+            }
+        }
+
+        /// <summary>
+        /// Applies a tint override to a block position.
+        /// </summary>
+        public void SetTint(int x, int y, int z, Color32 color)
+        {
+            int index = ChunkConfig.ToIndex(x, y, z);
+            color.a = 255;
+            _tints[index] = color;
+        }
+
+        /// <summary>
+        /// Removes a tint override from a block position.
+        /// </summary>
+        public void ClearTint(int x, int y, int z)
+        {
+            int index = ChunkConfig.ToIndex(x, y, z);
+            _tints[index] = default;
+        }
+
+        /// <summary>
+        /// Clears all tint overrides.
+        /// </summary>
+        public void ClearAllTints()
+        {
+            for (int i = 0; i < _tints.Length; i++)
+            {
+                _tints[i] = default;
             }
         }
 
@@ -48,6 +87,10 @@ namespace RobbieCraft.World
             if (_blocks.IsCreated)
             {
                 _blocks.Dispose();
+            }
+            if (_tints.IsCreated)
+            {
+                _tints.Dispose();
             }
         }
     }

--- a/Assets/Scripts/World/ChunkMeshData.cs
+++ b/Assets/Scripts/World/ChunkMeshData.cs
@@ -1,5 +1,6 @@
 using Unity.Collections;
 using Unity.Mathematics;
+using UnityEngine;
 
 namespace RobbieCraft.World
 {
@@ -12,6 +13,7 @@ namespace RobbieCraft.World
         public NativeList<int> Triangles;
         public NativeList<float3> Normals;
         public NativeList<float2> Uv;
+        public NativeList<Color32> Colors;
 
         public ChunkMeshData(Allocator allocator)
         {
@@ -19,6 +21,7 @@ namespace RobbieCraft.World
             Triangles = new NativeList<int>(allocator);
             Normals = new NativeList<float3>(allocator);
             Uv = new NativeList<float2>(allocator);
+            Colors = new NativeList<Color32>(allocator);
         }
 
         public void Dispose()
@@ -27,6 +30,7 @@ namespace RobbieCraft.World
             if (Triangles.IsCreated) Triangles.Dispose();
             if (Normals.IsCreated) Normals.Dispose();
             if (Uv.IsCreated) Uv.Dispose();
+            if (Colors.IsCreated) Colors.Dispose();
         }
     }
 }

--- a/checklist.md
+++ b/checklist.md
@@ -17,15 +17,15 @@ Phase 1 – Core Foundations (Week 1)
 
 ✅ Block & Registry
 
-[ ] Create BlockType registry (ScriptableObject).
+[x] Create BlockType registry (ScriptableObject).
 
-[ ] Add material atlas (2048×2048).
+[x] Add material atlas (2048×2048).
 
-[ ] Implement durability + break times.
+[x] Implement durability + break times.
 
-[ ] Implement block tinting system for Rainbow Painter.
+[x] Implement block tinting system for Rainbow Painter.
 
-[ ] Add special block types (Candy, Robot, Ice).
+[x] Add special block types (Candy, Robot, Ice).
 
 
 ✅ Inventory & Hotbar


### PR DESCRIPTION
## Summary
- create a block type registry and material atlas assets to describe block visuals and durability
- update chunk data, meshing, and world chunk systems to support vertex colors and per-block tint overrides
- add a block tinting helper and wire the world manager to provide registry data to generated chunks

## Testing
- Not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68dad61223f0832a8bbd45d6d50ca86a